### PR TITLE
Add verbosity control to metadata classes for flexible logging

### DIFF
--- a/src/czitools/_tests/test_instrument.py
+++ b/src/czitools/_tests/test_instrument.py
@@ -126,5 +126,6 @@ def test_objectives(czifile: str, result: Dict) -> None:
 
     out = obj.__dict__
     del out['czisource']
+    del out["verbose"]
 
     assert (out == result)

--- a/src/czitools/_tests/test_scaling.py
+++ b/src/czitools/_tests/test_scaling.py
@@ -27,6 +27,7 @@ def test_scaling1(czifile: str, results: Dict) -> None:
     out = czi_scaling.__dict__
 
     del out['czisource']
+    del out["verbose"]
 
     assert (out == results)
 

--- a/src/czitools/metadata_tools/add_metadata.py
+++ b/src/czitools/metadata_tools/add_metadata.py
@@ -16,9 +16,11 @@ class CziAddMetaData:
     customattributes: Optional[Box] = field(init=False, default=None)
     displaysetting: Optional[Box] = field(init=False, default=None)
     layers: Optional[Box] = field(init=False, default=None)
+    verbose: bool = False
 
     def __post_init__(self):
-        logger.info("Reading additional Metedata from CZI image data.")
+        if self.verbose:
+            logger.info("Reading additional Metedata from CZI image data.")
 
         if isinstance(self.czisource, Box):
             czi_box = self.czisource
@@ -28,29 +30,29 @@ class CziAddMetaData:
         if czi_box.has_experiment:
             self.experiment = czi_box.ImageDocument.Metadata.Experiment
         else:
-            # print("No Experiment information found.")
-            logger.info("No Experiment information found.")
+            if self.verbose:
+                logger.info("No Experiment information found.")
 
         if czi_box.has_hardware:
             self.hardwaresetting = czi_box.ImageDocument.Metadata.HardwareSetting
         else:
-            # print("No HardwareSetting information found.")
-            logger.info("No HardwareSetting information found.")
+            if self.verbose:
+                logger.info("No HardwareSetting information found.")
 
         if czi_box.has_customattr:
             self.customattributes = czi_box.ImageDocument.Metadata.CustomAttributes
         else:
-            # print("No CustomAttributes information found.")
-            logger.info("No CustomAttributes information found.")
+            if self.verbose:
+                logger.info("No CustomAttributes information found.")
 
         if czi_box.has_disp:
             self.displaysetting = czi_box.ImageDocument.Metadata.DisplaySetting
         else:
-            # print("No DisplaySetting information found.")
-            logger.info("No DisplaySetting information found.")
+            if self.verbose:
+                logger.info("No DisplaySetting information found.")
 
         if czi_box.has_layers:
             self.layers = czi_box.ImageDocument.Metadata.Layers
         else:
-            # print("No Layers information found.")
-            logger.info("No Layers information found.")
+            if self.verbose:
+                logger.info("No Layers information found.")

--- a/src/czitools/metadata_tools/attachment.py
+++ b/src/czitools/metadata_tools/attachment.py
@@ -16,9 +16,11 @@ class CziAttachments:
     has_preview: Optional[bool] = field(init=False, default=False)
     has_prescan: Optional[bool] = field(init=False, default=False)
     names: Optional[List[str]] = field(init=False, default_factory=lambda: [])
+    verbose: bool = False
 
     def __post_init__(self):
-        logger.info("Reading AttachmentImages from CZI image data.")
+        if self.verbose:
+            logger.info("Reading AttachmentImages from CZI image data.")
 
         try:
             import czifile
@@ -30,9 +32,10 @@ class CziAttachments:
                 self.czisource = self.czisource.filepath
 
             if validators.url(self.czisource):
-                logger.warning(
-                    "Reading Attachments from CZI via a link is not supported."
-                )
+                if self.verbose:
+                    logger.warning(
+                        "Reading Attachments from CZI via a link is not supported."
+                    )
             else:
                 # create CZI-object using czifile library
                 with czifile.CziFile(self.czisource) as cz:
@@ -42,13 +45,16 @@ class CziAttachments:
 
                     if "SlidePreview" in self.names:
                         self.has_preview = True
-                        logger.info("Attachment SlidePreview found.")
+                        if self.verbose:
+                            logger.info("Attachment SlidePreview found.")
                     if "Label" in self.names:
                         self.has_label = True
-                        logger.info("Attachment Label found.")
+                        if self.verbose:
+                            logger.info("Attachment Label found.")
                     if "Prescan" in self.names:
                         self.has_prescan = True
-                        logger.info("Attachment Prescan found.")
+                        if self.verbose:
+                            logger.info("Attachment Prescan found.")
 
         except ImportError as e:
             logger.warning(

--- a/src/czitools/metadata_tools/boundingbox.py
+++ b/src/czitools/metadata_tools/boundingbox.py
@@ -43,19 +43,16 @@ class CziBoundingBox:
                 self.scenes_bounding_rect = czidoc.scenes_bounding_rectangle
             except Exception as e:
                 self.scenes_bounding_rect = None
-                # print("Scenes Bounding rectangle not found.")
                 logger.info("Scenes Bounding rectangle not found.")
 
             try:
                 self.total_rect = czidoc.total_bounding_rectangle
             except Exception as e:
                 self.total_rect = None
-                # print("Total Bounding rectangle not found.")
                 logger.info("Total Bounding rectangle not found.")
 
             try:
                 self.total_bounding_box = czidoc.total_bounding_box
             except Exception as e:
                 self.total_bounding_box = None
-                # print("Total Bounding Box not found.")
                 logger.info("Total Bounding Box not found.")

--- a/src/czitools/metadata_tools/boundingbox.py
+++ b/src/czitools/metadata_tools/boundingbox.py
@@ -19,11 +19,13 @@ class CziBoundingBox:
     total_bounding_box: Optional[Dict[str, tuple]] = field(
         init=False, default_factory=lambda: []
     )
-
+    verbose: bool = False
+    
     # TODO Is this really needed as a separate class or better integrate directly into CziMetadata class?
 
     def __post_init__(self):
-        logger.info("Reading BoundingBoxes from CZI image data.")
+        if self.verbose:
+            logger.info("Reading BoundingBoxes from CZI image data.")
 
         pyczi_readertype = pyczi.ReaderFileInputTypes.Standard
 

--- a/src/czitools/metadata_tools/channel.py
+++ b/src/czitools/metadata_tools/channel.py
@@ -16,7 +16,7 @@ class CziChannelInfo:
     colors: List[str] = field(init=False, default_factory=lambda: [])
     clims: List[List[float]] = field(init=False, default_factory=lambda: [])
     gamma: List[float] = field(init=False, default_factory=lambda: [])
-    verbose: bool = field(init=False, default=False)
+    verbose: bool = False
     
     def __post_init__(self):
         if self.verbose:

--- a/src/czitools/metadata_tools/channel.py
+++ b/src/czitools/metadata_tools/channel.py
@@ -16,9 +16,11 @@ class CziChannelInfo:
     colors: List[str] = field(init=False, default_factory=lambda: [])
     clims: List[List[float]] = field(init=False, default_factory=lambda: [])
     gamma: List[float] = field(init=False, default_factory=lambda: [])
-
+    verbose: bool = field(init=False, default=False)
+    
     def __post_init__(self):
-        logger.info("Reading Channel Information from CZI image data.")
+        if self.verbose:
+            logger.info("Reading Channel Information from CZI image data.")
 
         if isinstance(self.czisource, Box):
             czi_box = self.czisource

--- a/src/czitools/metadata_tools/czi_metadata.py
+++ b/src/czitools/metadata_tools/czi_metadata.py
@@ -83,6 +83,7 @@ class CziMetadata:
     scene_size_consistent: Optional[Tuple[int]] = field(
         init=False, default_factory=lambda: ()
     )
+    verbose: bool = False
     """
     Create a CziMetadata object from the filename of the CZI image file.
     """
@@ -135,7 +136,7 @@ class CziMetadata:
             )
 
         # get the dimensions and order
-        self.image = CziDimensions(self.czi_box)
+        self.image = CziDimensions(self.czi_box, verbose=self.verbose)
 
         # get metadata_tools using pylibCZIrw
         with pyczi.open_czi(self.filepath, self.pyczi_readertype) as czidoc:
@@ -186,31 +187,31 @@ class CziMetadata:
             self.ismosaic = True
 
         # get the bounding boxes
-        self.bbox = CziBoundingBox(self.czi_box)
+        self.bbox = CziBoundingBox(self.czi_box, verbose=self.verbose)
 
         # get information about channels
-        self.channelinfo = CziChannelInfo(self.czi_box)
+        self.channelinfo = CziChannelInfo(self.czi_box, verbose=self.verbose)
 
         # get scaling info
-        self.scale = CziScaling(self.czi_box)
+        self.scale = CziScaling(self.czi_box, verbose=self.verbose)
 
         # get objective information
-        self.objective = CziObjectives(self.czi_box)
+        self.objective = CziObjectives(self.czi_box, verbose=self.verbose)
 
         # get detector information
-        self.detector = CziDetector(self.czi_box)
+        self.detector = CziDetector(self.czi_box, verbose=self.verbose)
 
         # get detector information
-        self.microscope = CziMicroscope(self.czi_box)
+        self.microscope = CziMicroscope(self.czi_box, verbose=self.verbose)
 
         # get information about sample carrier and wells etc.
-        self.sample = CziSampleInfo(self.czi_box)
+        self.sample = CziSampleInfo(self.czi_box, verbose=self.verbose)
 
         # get additional metainformation
-        self.add_metadata = CziAddMetaData(self.czi_box)
+        self.add_metadata = CziAddMetaData(self.czi_box, verbose=self.verbose)
 
         # check for attached label or preview image
-        self.attachments = CziAttachments(self.czi_box)
+        self.attachments = CziAttachments(self.czi_box, verbose=self.verbose)
 
     # can be also used without creating an instance of the class
     @staticmethod

--- a/src/czitools/metadata_tools/detector.py
+++ b/src/czitools/metadata_tools/detector.py
@@ -18,10 +18,12 @@ class CziDetector:
     gain: List[float] = field(init=False, default_factory=lambda: [])
     zoom: List[float] = field(init=False, default_factory=lambda: [])
     amplificationgain: List[float] = field(init=False, default_factory=lambda: [])
-
+    verbose: bool = False
+    
     def __post_init__(self):
-        logger.info("Reading Detector Information from CZI image data.")
-
+        if self.verbose:
+            logger.info("Reading Detector Information from CZI image data.")    
+            
         if isinstance(self.czisource, Box):
             czi_box = self.czisource
         else:

--- a/src/czitools/metadata_tools/dimension.py
+++ b/src/czitools/metadata_tools/dimension.py
@@ -34,6 +34,7 @@ class CziDimensions:
     SizeI: Optional[int] = field(init=False, default=None)
     SizeV: Optional[int] = field(init=False, default=None)
     SizeB: Optional[int] = field(init=False, default=None)
+    verbose: bool = False
     """Dataclass containing the image dimensions.
 
     Information official CZI Dimension Characters:
@@ -52,9 +53,10 @@ class CziDimensions:
     """
 
     def __post_init__(self):
+        if self.verbose:
+            logger.info("Reading Dimensions from CZI image data.")
 
         self.set_dimensions()
-        logger.info("Reading Dimensions from CZI image data.")
 
         # set dimensions in XY with respect to possible down scaling
         self.SizeX_sf = self.SizeX

--- a/src/czitools/metadata_tools/microscope.py
+++ b/src/czitools/metadata_tools/microscope.py
@@ -13,9 +13,11 @@ class CziMicroscope:
     Id: Optional[str] = field(init=False)
     Name: Optional[str] = field(init=False)
     System: Optional[str] = field(init=False)
-
+    verbose: bool = False
+    
     def __post_init__(self):
-        logger.info("Reading Microscope Information from CZI image data.")
+        if self.verbose:
+            logger.info("Reading Microscope Information from CZI image data.")
 
         if isinstance(self.czisource, Box):
             czi_box = self.czisource

--- a/src/czitools/metadata_tools/objective.py
+++ b/src/czitools/metadata_tools/objective.py
@@ -19,9 +19,11 @@ class CziObjectives:
     immersion: List[Optional[str]] = field(init=False, default_factory=lambda: [])
     tubelensmag: List[Optional[float]] = field(init=False, default_factory=lambda: [])
     totalmag: List[Optional[float]] = field(init=False, default_factory=lambda: [])
-
+    verbose: bool = False
+    
     def __post_init__(self):
-        logger.info("Reading Objective Information from CZI image data.")
+        if self.verbose:
+            logger.info("Reading Objective Information from CZI image data.")  
 
         if isinstance(self.czisource, Box):
             czi_box = self.czisource

--- a/src/czitools/metadata_tools/objective.py
+++ b/src/czitools/metadata_tools/objective.py
@@ -46,7 +46,8 @@ class CziObjectives:
                 objective = None
 
         elif not czi_box.has_objectives:
-            logger.info("No Objective Information found.")
+            if self.verbose:
+                logger.info("No Objective Information found.")
 
         # check if tubelens metadata_tools exist
         if czi_box.has_tubelenses:
@@ -59,7 +60,8 @@ class CziObjectives:
                 if tubelens.Magnification is not None:
                     self.tubelensmag.append(float(tubelens.Magnification))
                 elif tubelens.Magnification is None:
-                    logger.warning("No tubelens magnification found. Use 1.0x instead.")
+                    if self.verbose:
+                        logger.warning("No tubelens magnification found. Use 1.0x instead.")
                     self.tubelensmag.append(1.0)
 
             elif isinstance(tubelens, BoxList):
@@ -71,7 +73,8 @@ class CziObjectives:
                 self.totalmag = [i * j for i in self.objmag for j in self.tubelensmag]
 
         elif not czi_box.has_tubelens:
-            logger.info("No Tublens Information found.")
+            if self.verbose:
+                logger.info("No Tublens Information found.")
 
         if self.objmag is not None and self.tubelensmag == []:
             self.totalmag = self.objmag

--- a/src/czitools/metadata_tools/sample.py
+++ b/src/czitools/metadata_tools/sample.py
@@ -25,9 +25,11 @@ class CziSampleInfo:
     scene_stageY: List[float] = field(init=False, default_factory=lambda: [])
     image_stageX: float = field(init=False, default=None)
     image_stageY: float = field(init=False, default=None)
+    verbose: bool = False
 
     def __post_init__(self):
-        logger.info("Reading SampleCarrier Information from CZI image data.")
+        if self.verbose:
+            logger.info("Reading SampleCarrier Information from CZI image data.")
 
         if isinstance(self.czisource, Box):
             czi_box = self.czisource

--- a/src/czitools/metadata_tools/scaling.py
+++ b/src/czitools/metadata_tools/scaling.py
@@ -23,9 +23,11 @@ class CziScaling:
     # scalefactorXY: Optional[float] = field(init=False, default=None)
     unit: Optional[str] = field(init=True, default="micron")
     zoom: Annotated[float, ValueRange(0.01, 1.0)] = field(init=True, default=1.0)
-
+    verbose: bool = False
+    
     def __post_init__(self):
-        logger.info("Reading Scaling from CZI image data.")
+        if self.verbose:
+            logger.info("Reading Scaling from CZI image data.")   
 
         if isinstance(self.czisource, Box):
             czi_box = self.czisource


### PR DESCRIPTION
Summary: This pull request introduces a verbose flag across several key classes within the czitools.metadata_tools module. The verbose flag is added as a boolean attribute, allowing for more controlled and flexible logging behavior in downstream projects. By default, logging will be skipped unless the verbose flag is explicitly set to True, allowing developers to avoid unwanted logging in production or other scripts that utilize this library.

Changes:

Added verbose: bool = False as an attribute to each class, defaulting to False.
Implemented a check within the __post_init__ method of each dataclass to conditionally log messages if verbose is True.
This enhancement provides more control over logging output and prevents automatic console logging in projects using this library unless explicitly enabled.
Affected Classes:

CziScaling
CziDimensions
CziBoundingBox
CziChannelInfo
CziObjectives
CziMicroscope
CziDetector
By adding this control, I aim to prevent unwanted logs during typical usage unless verbosity is needed for debugging or development purposes.

Motivation: Previously, logs were always output to the console during initialization, which could clutter the logs of projects using this package. This change allows users of the czitools library to suppress logs unless required, improving the user experience for those integrating it into larger pipelines or tools.